### PR TITLE
Исправлена ошибка в "Минимальный импорт"

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ override func tableView(_ tableView: UITableView, numberOfRowsInSection section:
 ```
 ### Минимальный импорт
 
-Соблюдайте минимальное количество импортов. Например, опустите импорт `UIKit`, если импортируете `Foundation`.
+Соблюдайте минимальное количество импортов. Например, опустите импорт `Foundation`, если импортируете `UIKit`.
 
 ## Отступы
 


### PR DESCRIPTION
При импорте `UIKit` можно опустить импорт `Foundation`, так как `UIKit` содержит в себе `import Foundation` (но не наоборот).